### PR TITLE
[ feat ] 자바스크립트에 데이터 타입을 사전에 정의하여 에러를 예방하는 방법

### DIFF
--- a/why-ts/app.js
+++ b/why-ts/app.js
@@ -9,10 +9,35 @@ let address = document.querySelector('#address');
 // user data
 let userData = {};
 
+/**
+ * @typedef {object} Address
+ * @property {string} street
+ * @property {String} city
+ */
+
+
+/**
+ * @typedef {object} User
+ * @Property {string} name
+ * @property {string} email
+ * @property {Address} address
+ */
+
+
+/**
+ * 
+ * @returns {Promise<User>}
+ */
+function fetchUser() {
+    return axios.get(url);
+  }
+  
+  fetchUser().then(function(response) {
+    response.address.city;
+  })
 
 function startApp() {
-    axios
-        .get(url)
+    fetchUser()
         .then(function (response) {
             console.log(response.data);
             userData = response.data;


### PR DESCRIPTION
- [ ] 자바스크립트에 @typedef를 활용하여 객체의 타입을 지정

```
/**
 * @typedef {object} Address
 * @property {string} street
 * @property {String} city
 */


/**
 * @typedef {object} User
 * @Property {string} name
 * @property {string} email
 * @property {Address} address
 */


/**
 * 
 * @returns {Promise<User>}
 */
function fetchUser() {
    return axios.get(url);
  }
```