### PR TITLE
[ feat ] todo 관련 나머지 함수들 타입 지정 마무리

### DIFF
--- a/1_todo/src/index.ts
+++ b/1_todo/src/index.ts
@@ -1,4 +1,4 @@
-let todoItems;
+let todoItems: any;
 
 // api
 function fetchTodoItems() {
@@ -16,7 +16,7 @@ function fetchTodos() {
   return todos;
 }
 
-function addTodo(todo) {
+function addTodo(todo): void {
   todoItems.push(todo);
 }
 

--- a/1_todo/src/index.ts
+++ b/1_todo/src/index.ts
@@ -1,4 +1,4 @@
-let todoItems: any;
+let todoItems: any; 
 
 // api
 function fetchTodoItems() {

--- a/1_todo/src/index.ts
+++ b/1_todo/src/index.ts
@@ -1,7 +1,7 @@
-let todoItems: any; 
+let todoItems: object[]; 
 
 // api
-function fetchTodoItems() {
+function fetchTodoItems(): object[] {
   const todos = [
     { id: 1, title: '안녕', done: false },
     { id: 2, title: '타입', done: false },
@@ -11,20 +11,20 @@ function fetchTodoItems() {
 }
 
 // crud methods
-function fetchTodos() {
+function fetchTodos(): object[] {
   const todos = fetchTodoItems();
   return todos;
 }
 
-function addTodo(todo): void {
+function addTodo(todo: object): void {
   todoItems.push(todo);
 }
 
-function deleteTodo(index) {
+function deleteTodo(index: number): void {
   todoItems.splice(index, 1);
 }
 
-function completeTodo(index, todo) {
+function completeTodo(index: number, todo: object) {
   todo.done = true;
   todoItems.splice(index, 1, todo);
 }

--- a/1_todo/tsconfig.json
+++ b/1_todo/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
-    "noImplicitAny": false
+    "noImplicitAny": true
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
#29
- [x] todoItems의 타입을 더 구체적으로 지정 {id: number, title: string , done: boolean}[];
- [x] todo의 타입을 더 구체적으로 지정 {id:number, title: string, done: boolean}
- [x] showComplete 완료된 투두 목록에 대해서는 object[ ]을 반환하도록 타입 지정
- [x] addTwoTodoItmes에 item 객체를 만들어서 addTodo가 호출되도록 기능 개발

```
todoItems = fetchTodoItems();
addTwoTodoItems();
log();

```

스크린샷
![image](https://github.com/user-attachments/assets/27b471d9-44e1-4e51-ac8f-04bab74063fe)
