### PR TITLE
[ feat ] 제네릭 타입 제한

### DIFF
--- a/class-note/8_generics.ts
+++ b/class-note/8_generics.ts
@@ -71,3 +71,13 @@ interface Drowpdown2<T> {
 }
 
 const obj2: Drowpdown2<string> = {value:'abc', lselected: false};
+
+// 제네릭의 타입 제한
+function logTextLength<T>(text: T[]): T[] {
+    text.forEach(function(text){
+        console.log(text);
+    })
+    return text;
+}    
+
+logTextLength<string>(['hi']);


### PR DESCRIPTION
- [x] 제네릭 타입을 엄격하게 제한하는 방법

```
// 제네릭의 타입 제한
function logTextLength<T>(text: T[]): T[] {
    text.forEach(function(text){
        console.log(text);
    })
    return text;
}    

logTextLength<string>(['hi']);
```