### PR TITLE
[ feat ] 제네릭 타입 제한2 - 정의된 타입 이용하기

### DIFF
--- a/class-note/8_generics.js
+++ b/class-note/8_generics.js
@@ -1,0 +1,60 @@
+function logText(text) {
+    console.log(text);
+    return text;
+}
+logText(10); // 숫자 10
+logText('하이'); // 문자열 하이
+logText(true); // 진위값 true
+function logText2(text2) {
+    console.log(text2);
+    return text2;
+}
+logText2(10); // 숫자 10
+logText2('하이'); // 문자열 하이
+logText2(true); // 진위값 true
+function logText3(text) {
+    console.log(text);
+    text.split('').reverse().join('');
+    return text;
+}
+function logNumber(text) {
+    console.log(text);
+    return text;
+}
+function logBoolean(text) {
+    console.log(Boolean);
+    return text;
+}
+logNumber(10); // 숫자 10
+logText3('하이'); // 문자열 하이
+logBoolean(true); // 진위값 true
+function logText4(text) {
+    console.log(text);
+    return text;
+}
+var a = logText4('하이'); // 문자열 하이
+var b = logText4(10); // 숫자 10
+function logText5(text) {
+    console.log(text);
+    return text;
+}
+var c = logText5('하이');
+c.split('');
+var d = logText5(10);
+var login = logText5(true);
+var obj = { value: 'abc', selected: false };
+var obj2 = { value: 'abc', lselected: false };
+// 제네릭의 타입 제한
+function logTextLength(text) {
+    text.forEach(function (text) {
+        console.log(text);
+    });
+    return text;
+}
+logTextLength(['hi']);
+function logTextLength2(text) {
+    text.length;
+    return text;
+}
+logTextLength2('a');
+logTextLength2({ length: 10 });

--- a/class-note/8_generics.ts
+++ b/class-note/8_generics.ts
@@ -81,3 +81,16 @@ function logTextLength<T>(text: T[]): T[] {
 }    
 
 logTextLength<string>(['hi']);
+
+// 제네릭 타입 제한 2 - 정의된 타입 이용하기
+interface LengthType {
+    length: number;
+}
+
+function logTextLength2<T extends LengthType>(text: T): T {
+    text.length
+    return text;
+} 
+
+logTextLength2('a');
+logTextLength2({length: 10})


### PR DESCRIPTION
- [x] 제네릭과 인터페에스를 이용하여 인터페이스에 정의된 타입으로 제네릭의 타입 제한

```
// 제네릭 타입 제한 2 - 정의된 타입 이용하기
interface LengthType {
    length: number;
}

function logTextLength2<T extends LengthType>(text: T): T {
    text.length
    return text;
} 

logTextLength2('a');
logTextLength2({length: 10})


```

![image](https://github.com/user-attachments/assets/5c4442fd-f014-40ef-8e4b-13217457f714)
